### PR TITLE
build: provide devcontainer for P development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,21 @@
+FROM mcr.microsoft.com/vscode/devcontainers/base:ubuntu-22.04
+# Update and install dependencies
+RUN apt-get update -y
+RUN apt-get upgrade -y
+RUN apt-get install build-essential -y
+RUN apt-get install wget -y
+# The P compiler is implemented in C# and hence the tool chain requires dotnet.
+# P currently uses the specific version of .Net SDK 8.0.
+RUN wget https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+RUN dpkg -i packages-microsoft-prod.deb
+RUN rm packages-microsoft-prod.deb
+RUN apt install -y dotnet-sdk-8.0
+
+# Verify .Net is installed
+RUN dotnet --list-sdks
+
+# The P compiler also requires Java Runtime (version 11 or higher).
+RUN apt install -y default-jre
+
+# Verify JRE is installed
+RUN java -version

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-dockerfile
+{
+    "name": "Existing Dockerfile",
+    "build": {
+        "context": ".",
+        "dockerfile": "Dockerfile"
+    },
+    // Features to add to the dev container. More info: https://containers.dev/features.
+    // "features": {},
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
+    "postStartCommand": "dotnet tool install --global P && git config --global --add safe.directory ${containerWorkspaceFolder}"
+    // Configure tool-specific properties.
+    // "customizations": {},
+    // Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.
+    // "remoteUser": "devcontainer"
+}


### PR DESCRIPTION
# Overview
This PR provides a dev container to simplify environment set-up for developing using the P language. The prerequisite software (C# .NET and Java > 11) for P is installed on an Ubuntu 22.04 base image.

Based on: https://p-org.github.io/P/getstarted/install/